### PR TITLE
[FIX] - Changed the Postgres Engine version

### DIFF
--- a/infra/deploy/database.tf
+++ b/infra/deploy/database.tf
@@ -36,7 +36,7 @@ resource "aws_db_instance" "main" {
   allocated_storage          = 20
   storage_type               = "gp2"
   engine                     = "postgres"
-  engine_version             = "15.3"
+  engine_version             = "16.3"
   auto_minor_version_upgrade = true
   instance_class             = "db.t4g.micro"
   username                   = var.db_username


### PR DESCRIPTION
Ran the below command to list out supported Postgres versions available currently. Picked version 16.3 from the list. 

> aws rds describe-db-engine-versions --engine postgres --query '*[].[EngineVersion]' --output text --region us-east-1 | sort

NOTE :- Make sure to authenticate with `aws-vault` first before running the above command.

If `aws-vault` is not setup in the machine, we'll need to run the below command by setting the actual values for AWS creds.

> AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... ECR_REPO=... aws rds describe-db-engine-versions --engine postgres --query '*[].[EngineVersion]' --output text --region us-east-1 | sort